### PR TITLE
Add PDF receipt generation and improve cart checkout flow

### DIFF
--- a/backend/src/controllers/cartController.js
+++ b/backend/src/controllers/cartController.js
@@ -8,11 +8,7 @@ import {
   updateCartItemQuantity,
 } from "../services/cartService.js";
 import { getProductById } from "../services/productService.js";
-
-const calculateTotals = (items) => {
-  const subtotal = items.reduce((sum, item) => sum + item.quantity * Number(item.unitPrice), 0);
-  return { subtotal, total: subtotal };
-};
+import { calculateTotals } from "../utils/totals.js";
 
 const ensureCart = async (userId) => {
   let cart = await getActiveCart(userId);

--- a/backend/src/controllers/orderController.js
+++ b/backend/src/controllers/orderController.js
@@ -3,10 +3,13 @@ import { getActiveCart, getCartItems } from "../services/cartService.js";
 import {
   createOrderFromCart,
   getAllOrders,
+  getOrderById,
   getOrderItems,
   getOrdersForUser,
   updateOrderStatus,
 } from "../services/orderService.js";
+import { generateOrderReceipt } from "../services/receiptService.js";
+import { calculateTotals } from "../utils/totals.js";
 
 export const checkout = async (req, res) => {
   const errors = validationResult(req);
@@ -27,8 +30,14 @@ export const checkout = async (req, res) => {
 
     const orderId = await createOrderFromCart({ userId: req.user.id, cartId: cart.id, items });
     const orderItems = await getOrderItems(orderId);
+    const totals = calculateTotals(orderItems);
 
-    res.status(201).json({ orderId, items: orderItems });
+    res.status(201).json({
+      orderId,
+      items: orderItems,
+      totals,
+      receipt: { url: `/orders/${orderId}/receipt` },
+    });
   } catch (error) {
     console.error("Error al procesar checkout", error);
     res.status(500).json({ message: "Error interno del servidor" });
@@ -39,10 +48,15 @@ export const listMyOrders = async (req, res) => {
   try {
     const orders = await getOrdersForUser(req.user.id);
     const enrichedOrders = await Promise.all(
-      orders.map(async (order) => ({
-        ...order,
-        items: await getOrderItems(order.id),
-      }))
+      orders.map(async (order) => {
+        const items = await getOrderItems(order.id);
+        return {
+          ...order,
+          items,
+          totals: calculateTotals(items),
+          receipt: { url: `/orders/${order.id}/receipt` },
+        };
+      })
     );
 
     res.json({ orders: enrichedOrders });
@@ -56,15 +70,57 @@ export const listAllOrders = async (req, res) => {
   try {
     const orders = await getAllOrders();
     const enrichedOrders = await Promise.all(
-      orders.map(async (order) => ({
-        ...order,
-        items: await getOrderItems(order.id),
-      }))
+      orders.map(async (order) => {
+        const items = await getOrderItems(order.id);
+        return {
+          ...order,
+          items,
+          totals: calculateTotals(items),
+          receipt: { url: `/orders/${order.id}/receipt` },
+        };
+      })
     );
 
     res.json({ orders: enrichedOrders });
   } catch (error) {
     console.error("Error obteniendo órdenes administrativas", error);
+    res.status(500).json({ message: "Error interno del servidor" });
+  }
+};
+
+export const downloadReceipt = async (req, res) => {
+  const { orderId } = req.params;
+
+  try {
+    const order = await getOrderById(orderId);
+    if (!order) {
+      return res.status(404).json({ message: "Orden no encontrada" });
+    }
+
+    const isOwner = order.userId === req.user.id;
+    const isAdmin = req.user.role === "admin";
+
+    if (!isOwner && !isAdmin) {
+      return res.status(403).json({ message: "No tienes permisos para este comprobante" });
+    }
+
+    const items = await getOrderItems(orderId);
+    const totals = calculateTotals(items);
+    const issuedAt = order.createdAt ? new Date(order.createdAt) : new Date();
+
+    const buffer = await generateOrderReceipt({
+      orderId: Number(orderId),
+      user: { name: order.customerName || req.user.name, email: order.customerEmail || req.user.email },
+      items,
+      totals,
+      issuedAt,
+    });
+
+    res.setHeader("Content-Type", "application/pdf");
+    res.setHeader("Content-Disposition", `attachment; filename="comprobante-pedido-${orderId}.pdf"`);
+    res.send(buffer);
+  } catch (error) {
+    console.error("Error generando comprobante", error);
     res.status(500).json({ message: "Error interno del servidor" });
   }
 };

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -3,15 +3,25 @@ import { ENV } from "../config/env.js";
 
 export const authenticate = (req, res, next) => {
   const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return res.status(401).json({ message: "No autenticado" });
+  const queryToken = typeof req.query.token === "string" ? req.query.token : null;
+
+  let token = null;
+  if (authHeader && authHeader.startsWith("Bearer ")) {
+    token = authHeader.split(" ")[1];
+  } else if (queryToken) {
+    token = queryToken;
   }
 
-  const token = authHeader.split(" ")[1];
+  if (!token) {
+    return res.status(401).json({ message: "No autenticado" });
+  }
 
   try {
     const decoded = jwt.verify(token, ENV.JWT_SECRET);
     req.user = decoded;
+    if (queryToken) {
+      delete req.query.token;
+    }
     next();
   } catch (error) {
     return res.status(401).json({ message: "Token inválido" });

--- a/backend/src/routes/orderRoutes.js
+++ b/backend/src/routes/orderRoutes.js
@@ -2,6 +2,7 @@ import { Router } from "express";
 import { body, param } from "express-validator";
 import {
   checkout,
+  downloadReceipt,
   listAllOrders,
   listMyOrders,
   updateOrderStatusController,
@@ -12,6 +13,12 @@ const router = Router();
 
 router.post("/checkout", authenticate, checkout);
 router.get("/mine", authenticate, listMyOrders);
+
+router.get(
+  "/:orderId/receipt",
+  [authenticate, param("orderId").isInt({ min: 1 })],
+  downloadReceipt
+);
 
 router.get("/", authenticate, requireAdmin, listAllOrders);
 

--- a/backend/src/services/orderService.js
+++ b/backend/src/services/orderService.js
@@ -61,6 +61,19 @@ export const getOrderItems = async (orderId) => {
   );
 };
 
+export const getOrderById = async (orderId) => {
+  const rows = await query(
+    `SELECT o.id, o.total, o.status, o.created_at AS createdAt, o.user_id AS userId,
+            u.name AS customerName, u.email AS customerEmail
+     FROM orders o
+     LEFT JOIN users u ON o.user_id = u.id
+     WHERE o.id = :orderId`,
+    { orderId }
+  );
+
+  return rows[0];
+};
+
 export const getAllOrders = async () => {
   return query(
     `SELECT o.id, o.total, o.status, o.created_at AS createdAt, u.name AS customerName, u.email

--- a/backend/src/services/receiptService.js
+++ b/backend/src/services/receiptService.js
@@ -1,0 +1,117 @@
+const escapePdfText = (text = "") => text.replace(/[\\()]/g, "\\$&");
+
+const buildLines = ({ user, items, totals, issuedAt }) => {
+  const formatter = new Intl.DateTimeFormat("es-MX", {
+    dateStyle: "long",
+    timeStyle: "short",
+  });
+  const dateLine = `Fecha: ${formatter.format(issuedAt)}`;
+  const lines = [
+    dateLine,
+    `Cliente: ${user?.name || "Invitado"}`,
+  ];
+
+  if (user?.email) {
+    lines.push(`Correo: ${user.email}`);
+  }
+
+  lines.push("", "Detalle del pedido:");
+
+  items.forEach((item) => {
+    const total = Number(item.quantity || 0) * Number(item.unitPrice ?? item.unit_price ?? 0);
+    lines.push(`${item.quantity}x ${item.name} - $${total.toFixed(2)}`);
+  });
+
+  const totalItems = items.reduce((sum, item) => sum + Number(item.quantity || 0), 0);
+
+  lines.push(
+    "",
+    `Artículos totales: ${totalItems}`,
+    `Subtotal: $${totals.subtotal.toFixed(2)}`,
+    `Total: $${totals.total.toFixed(2)}`,
+    "",
+    "¡Gracias por tu compra!"
+  );
+
+  return lines;
+};
+
+const createContentStream = ({ title, lines }) => {
+  const commands = [
+    "BT",
+    "/F1 20 Tf",
+    "72 760 Td",
+    `(${escapePdfText(title)}) Tj`,
+    "/F1 12 Tf",
+    "0 -28 Td",
+    "16 TL",
+  ];
+
+  if (lines.length) {
+    commands.push(`(${escapePdfText(lines[0])}) Tj`);
+    for (let i = 1; i < lines.length; i += 1) {
+      commands.push("T*");
+      if (lines[i]) {
+        commands.push(`(${escapePdfText(lines[i])}) Tj`);
+      }
+    }
+  }
+
+  commands.push("ET");
+  return commands.join("\n");
+};
+
+export const generateOrderReceipt = async ({ orderId, user, items, totals, issuedAt }) => {
+  const buffers = [];
+  let offset = 0;
+
+  const push = (content) => {
+    const buffer = Buffer.isBuffer(content) ? content : Buffer.from(content, "utf8");
+    buffers.push(buffer);
+    offset += buffer.length;
+  };
+
+  const objectOffsets = [];
+
+  const addObject = (body) => {
+    const index = objectOffsets.length + 1;
+    const objectString = `${index} 0 obj\n${body}\nendobj\n`;
+    objectOffsets.push(offset);
+    push(objectString);
+    return index;
+  };
+
+  const addStreamObject = (streamContent) => {
+    const length = Buffer.byteLength(streamContent, "utf8");
+    const index = objectOffsets.length + 1;
+    const objectString = `${index} 0 obj\n<< /Length ${length} >>\nstream\n${streamContent}\nendstream\nendobj\n`;
+    objectOffsets.push(offset);
+    push(objectString);
+    return index;
+  };
+
+  push("%PDF-1.4\n");
+
+  const contentStream = createContentStream({
+    title: `Comprobante de pedido #${orderId}`,
+    lines: buildLines({ user, items, totals, issuedAt }),
+  });
+
+  addObject("<< /Type /Catalog /Pages 2 0 R >>");
+  addObject("<< /Type /Pages /Kids [3 0 R] /Count 1 >>");
+  addObject("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>");
+  addStreamObject(contentStream);
+  addObject("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>");
+
+  const xrefOffset = offset;
+  let xref = `xref\n0 ${objectOffsets.length + 1}\n`;
+  xref += "0000000000 65535 f \n";
+  objectOffsets.forEach((value) => {
+    xref += `${value.toString().padStart(10, "0")} 00000 n \n`;
+  });
+  xref += `trailer\n<< /Size ${objectOffsets.length + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF`;
+
+  push(xref);
+
+  return Buffer.concat(buffers);
+};

--- a/backend/src/utils/totals.js
+++ b/backend/src/utils/totals.js
@@ -1,0 +1,9 @@
+export const calculateTotals = (items = []) => {
+  const subtotal = items.reduce((sum, item) => {
+    const quantity = Number(item.quantity || 0);
+    const unitPrice = Number(item.unitPrice ?? item.unit_price ?? 0);
+    return sum + quantity * unitPrice;
+  }, 0);
+
+  return { subtotal, total: subtotal };
+};

--- a/mobile/app/(tabs)/cart.jsx
+++ b/mobile/app/(tabs)/cart.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   View,
   Text,
@@ -12,6 +12,8 @@ import { Ionicons } from "@expo/vector-icons";
 import { useCart } from "@/contexts/CartContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { COLORS } from "@/constants/colors";
+import * as WebBrowser from "expo-web-browser";
+import { API_BASE_URL } from "@/services/api";
 
 const CartItem = ({ item, onIncrease, onDecrease, onRemove }) => (
   <View style={styles.itemCard}>
@@ -36,9 +38,18 @@ const CartItem = ({ item, onIncrease, onDecrease, onRemove }) => (
 
 export default function CartScreen() {
   const { items, totals, loading, updateItem, removeItem, checkout } = useCart();
-  const { user } = useAuth();
+  const { user, token } = useAuth();
   const [submitting, setSubmitting] = useState(false);
   const [message, setMessage] = useState(null);
+  const [receiptPath, setReceiptPath] = useState(null);
+  const [openingReceipt, setOpeningReceipt] = useState(false);
+
+  useEffect(() => {
+    if (items.length) {
+      setMessage(null);
+      setReceiptPath(null);
+    }
+  }, [items.length]);
 
   const handleIncrease = async (item) => {
     try {
@@ -78,12 +89,36 @@ export default function CartScreen() {
     try {
       setSubmitting(true);
       setMessage(null);
+      setReceiptPath(null);
       const order = await checkout();
-      setMessage(`¡Pedido #${order.orderId} recibido! Te avisaremos cuando esté listo.`);
+      const totalAmount = Number(order?.totals?.total ?? totals.total);
+      setReceiptPath(order?.receipt?.url || null);
+      setMessage(
+        `¡Pedido #${order.orderId} recibido! Total $${totalAmount.toFixed(2)}. Descarga tu comprobante cuando quieras.`
+      );
     } catch (err) {
       Alert.alert("No pudimos procesar tu pedido", err.message || "Intenta de nuevo más tarde");
     } finally {
       setSubmitting(false);
+    }
+  };
+
+  const handleOpenReceipt = async () => {
+    if (!receiptPath) return;
+    if (!token) {
+      Alert.alert("Inicia sesión", "Necesitas iniciar sesión para descargar tu comprobante.");
+      return;
+    }
+
+    try {
+      setOpeningReceipt(true);
+      const separator = receiptPath.includes("?") ? "&" : "?";
+      const url = `${API_BASE_URL}${receiptPath}${separator}token=${encodeURIComponent(token)}`;
+      await WebBrowser.openBrowserAsync(url);
+    } catch (err) {
+      Alert.alert("No se pudo abrir el comprobante", err.message || "Intenta nuevamente.");
+    } finally {
+      setOpeningReceipt(false);
     }
   };
 
@@ -129,6 +164,15 @@ export default function CartScreen() {
           <Text style={styles.summaryTotal}>${totals.total.toFixed(2)}</Text>
         </View>
         {message && <Text style={styles.success}>{message}</Text>}
+        {receiptPath && (
+          <TouchableOpacity style={styles.receiptButton} onPress={handleOpenReceipt} disabled={openingReceipt}>
+            {openingReceipt ? (
+              <ActivityIndicator color={COLORS.primary} />
+            ) : (
+              <Text style={styles.receiptButtonText}>Descargar comprobante</Text>
+            )}
+          </TouchableOpacity>
+        )}
         <TouchableOpacity style={styles.checkoutButton} onPress={handleCheckout} disabled={submitting}>
           {submitting ? (
             <ActivityIndicator color={COLORS.white} />
@@ -243,6 +287,20 @@ const styles = StyleSheet.create({
     borderRadius: 16,
     alignItems: "center",
     marginTop: 8,
+  },
+  receiptButton: {
+    borderWidth: 1.5,
+    borderColor: COLORS.primary,
+    paddingVertical: 14,
+    borderRadius: 16,
+    alignItems: "center",
+    marginTop: 8,
+    backgroundColor: COLORS.white,
+  },
+  receiptButtonText: {
+    color: COLORS.primary,
+    fontWeight: "700",
+    fontSize: 16,
   },
   checkoutText: {
     color: COLORS.white,

--- a/mobile/app/(tabs)/index.jsx
+++ b/mobile/app/(tabs)/index.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity, Image, ActivityIndicator } from "react-native";
 import { useRouter } from "expo-router";
-import { catalogApi, orderApi } from "@/services/api";
+import { catalogApi, orderApi, resolveImageUrl } from "@/services/api";
 import { COLORS } from "@/constants/colors";
 import { useCart } from "@/contexts/CartContext";
 import { useAuth } from "@/contexts/AuthContext";
@@ -11,10 +11,10 @@ const heroImage = {
 };
 const fallbackProductImage = "https://images.unsplash.com/photo-1488900128323-21503983a07e?auto=format&fit=crop&w=600&q=60";
 
-const getProductImage = (imageUrl) =>
-  imageUrl && imageUrl.startsWith("http")
-    ? { uri: imageUrl }
-    : { uri: fallbackProductImage };
+const getProductImage = (imageUrl) => {
+  const resolved = resolveImageUrl(imageUrl);
+  return { uri: resolved || fallbackProductImage };
+};
 
 export default function HomeScreen() {
   const router = useRouter();

--- a/mobile/app/(tabs)/menu.jsx
+++ b/mobile/app/(tabs)/menu.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   View,
   Text,
@@ -10,17 +10,17 @@ import {
   ActivityIndicator,
   RefreshControl,
 } from "react-native";
-import { catalogApi } from "@/services/api";
+import { catalogApi, resolveImageUrl } from "@/services/api";
 import { COLORS } from "@/constants/colors";
 import { useCart } from "@/contexts/CartContext";
 import { useLocalSearchParams } from "expo-router";
 
 const fallbackProductImage = "https://images.unsplash.com/photo-1488900128323-21503983a07e?auto=format&fit=crop&w=600&q=60";
 
-const getProductImage = (imageUrl) =>
-  imageUrl && imageUrl.startsWith("http")
-    ? { uri: imageUrl }
-    : { uri: fallbackProductImage };
+const getProductImage = (imageUrl) => {
+  const resolved = resolveImageUrl(imageUrl);
+  return { uri: resolved || fallbackProductImage };
+};
 
 const ProductCard = ({ product, onAdd }) => (
   <View style={styles.productCard}>
@@ -53,46 +53,56 @@ export default function MenuScreen() {
   const [error, setError] = useState(null);
   const { addItem } = useCart();
 
-  const fetchCategories = async () => {
+  const fetchCategories = useCallback(async () => {
     const response = await catalogApi.categories();
     return response.categories || [];
-  };
+  }, []);
 
-  const fetchProducts = async (filters = {}) => {
+  const fetchProducts = useCallback(async (filters = {}) => {
     const response = await catalogApi.products(filters);
     return response.products || [];
-  };
+  }, []);
 
-  const loadData = async ({ withCategories = false, filters = {} } = {}) => {
-    setLoading(true);
-    setError(null);
-    try {
-      if (withCategories) {
-        const cats = await fetchCategories();
-        setCategories(cats);
+  const loadData = useCallback(
+    async ({ withCategories = false, filters = {} } = {}) => {
+      setLoading(true);
+      setError(null);
+      try {
+        if (withCategories) {
+          const cats = await fetchCategories();
+          setCategories(cats);
+        }
+        const prods = await fetchProducts(filters);
+        setProducts(prods);
+      } catch (err) {
+        setError(err.message || "No pudimos obtener la carta");
+      } finally {
+        setLoading(false);
       }
-      const prods = await fetchProducts(filters);
-      setProducts(prods);
-    } catch (err) {
-      setError(err.message || "No pudimos obtener la carta");
-    } finally {
-      setLoading(false);
-    }
-  };
+    },
+    [fetchCategories, fetchProducts]
+  );
+
+  const hasLoadedOnce = useRef(false);
+  const latestSearchRef = useRef(search);
+
+  useEffect(() => {
+    latestSearchRef.current = search;
+  }, [search]);
 
   useEffect(() => {
     loadData({ withCategories: true, filters: { categoryId: defaultCategory } });
-  }, []);
+    hasLoadedOnce.current = true;
+  }, [defaultCategory, loadData]);
 
   useEffect(() => {
-    if (!loading) {
-      loadData({ filters: { categoryId: selectedCategory, search: search || undefined } });
-    }
-    }, [selectedCategory]);
+    if (!hasLoadedOnce.current) return;
+    loadData({ filters: { categoryId: selectedCategory, search: latestSearchRef.current || undefined } });
+  }, [selectedCategory, loadData]);
 
   const handleSearch = useCallback(async () => {
     await loadData({ filters: { categoryId: selectedCategory, search } });
-  }, [selectedCategory, search]);
+  }, [loadData, selectedCategory, search]);
 
   const handleAddToCart = async (productId) => {
     try {

--- a/mobile/services/api.js
+++ b/mobile/services/api.js
@@ -1,4 +1,14 @@
-const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL?.replace(/\/$/, "") || "http://localhost:5001/api";
+export const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL?.replace(/\/$/, "") || "http://localhost:5001/api";
+const API_ORIGIN = API_BASE_URL.replace(/\/api$/i, "");
+
+export const resolveImageUrl = (path) => {
+  if (!path) return null;
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+  const normalised = String(path).replace(/^\/+/, "");
+  return `${API_ORIGIN}/${normalised}`;
+};
 
 const createHeaders = (token) => {
   const headers = { "Content-Type": "application/json" };


### PR DESCRIPTION
## Summary
- add reusable totals utility and create server-side PDF receipts with a protected download route
- expose receipt links during checkout and order listings while accepting auth tokens via query for downloads
- update the mobile cart to open the PDF receipt in a browser and resolve product images from backend URLs across the app

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ec3693d244832ebd0d4a2f7b37936b