### PR TITLE
Add admin dashboard with product CRUD and user management

### DIFF
--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -1,0 +1,22 @@
+import { getDashboardMetrics } from "../services/adminService.js";
+import { listUsers } from "../services/userService.js";
+
+export const dashboardController = async (_req, res) => {
+  try {
+    const data = await getDashboardMetrics();
+    res.json(data);
+  } catch (error) {
+    console.error("Error obteniendo métricas administrativas", error);
+    res.status(500).json({ message: "Error interno del servidor" });
+  }
+};
+
+export const listUsersController = async (_req, res) => {
+  try {
+    const users = await listUsers();
+    res.json({ users });
+  } catch (error) {
+    console.error("Error listando usuarios", error);
+    res.status(500).json({ message: "Error interno del servidor" });
+  }
+};

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -1,0 +1,12 @@
+import { Router } from "express";
+import { dashboardController, listUsersController } from "../controllers/adminController.js";
+import { authenticate, requireAdmin } from "../middleware/auth.js";
+
+const router = Router();
+
+router.use(authenticate, requireAdmin);
+
+router.get("/dashboard", dashboardController);
+router.get("/users", listUsersController);
+
+export default router;

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -5,6 +5,7 @@ import authRoutes from "./routes/authRoutes.js";
 import productRoutes from "./routes/productRoutes.js";
 import cartRoutes from "./routes/cartRoutes.js";
 import orderRoutes from "./routes/orderRoutes.js";
+import adminRoutes from "./routes/adminRoutes.js";
 
 const app = express();
 
@@ -19,6 +20,7 @@ app.use("/api/auth", authRoutes);
 app.use("/api", productRoutes);
 app.use("/api/cart", cartRoutes);
 app.use("/api/orders", orderRoutes);
+app.use("/api/admin", adminRoutes);
 
 app.use((err, _req, res, _next) => {
   console.error("Unhandled error", err);

--- a/backend/src/services/adminService.js
+++ b/backend/src/services/adminService.js
@@ -1,0 +1,79 @@
+import { query } from "../config/db.js";
+
+const toNumber = (value) => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+export const getDashboardMetrics = async () => {
+  const [ordersSummary] = await query(
+    `SELECT
+        COUNT(*) AS totalOrders,
+        SUM(CASE WHEN status = 'pending' THEN 1 ELSE 0 END) AS pendingOrders,
+        SUM(CASE WHEN status = 'paid' THEN 1 ELSE 0 END) AS paidOrders,
+        SUM(CASE WHEN status = 'cancelled' THEN 1 ELSE 0 END) AS cancelledOrders,
+        SUM(CASE WHEN status <> 'cancelled' THEN total ELSE 0 END) AS totalRevenue
+      FROM orders`
+  );
+
+  const [inventorySummary] = await query(
+    `SELECT
+        COUNT(*) AS totalProducts,
+        SUM(CASE WHEN active = 1 THEN 1 ELSE 0 END) AS activeProducts,
+        SUM(CASE WHEN stock <= 5 THEN 1 ELSE 0 END) AS lowStockProducts
+      FROM products`
+  );
+
+  const salesByMonth = await query(
+    `SELECT
+        DATE_FORMAT(created_at, '%Y-%m') AS month,
+        COUNT(*) AS orders,
+        SUM(total) AS revenue
+      FROM orders
+      WHERE status <> 'cancelled'
+      GROUP BY DATE_FORMAT(created_at, '%Y-%m')
+      ORDER BY month DESC
+      LIMIT 6`
+  );
+
+  const topProducts = await query(
+    `SELECT
+        p.id,
+        p.name,
+        SUM(oi.quantity) AS unitsSold,
+        SUM(oi.quantity * oi.unit_price) AS revenue
+      FROM order_items oi
+      JOIN orders o ON oi.order_id = o.id
+      JOIN products p ON oi.product_id = p.id
+      WHERE o.status <> 'cancelled'
+      GROUP BY p.id, p.name
+      ORDER BY unitsSold DESC
+      LIMIT 5`
+  );
+
+  return {
+    summary: {
+      totalOrders: Number(ordersSummary?.totalOrders || 0),
+      pendingOrders: Number(ordersSummary?.pendingOrders || 0),
+      paidOrders: Number(ordersSummary?.paidOrders || 0),
+      cancelledOrders: Number(ordersSummary?.cancelledOrders || 0),
+      totalRevenue: toNumber(ordersSummary?.totalRevenue || 0),
+    },
+    inventory: {
+      totalProducts: Number(inventorySummary?.totalProducts || 0),
+      activeProducts: Number(inventorySummary?.activeProducts || 0),
+      lowStockProducts: Number(inventorySummary?.lowStockProducts || 0),
+    },
+    salesByMonth: salesByMonth.map((row) => ({
+      month: row.month,
+      orders: Number(row.orders || 0),
+      revenue: toNumber(row.revenue || 0),
+    })),
+    topProducts: topProducts.map((row) => ({
+      id: row.id,
+      name: row.name,
+      unitsSold: Number(row.unitsSold || 0),
+      revenue: toNumber(row.revenue || 0),
+    })),
+  };
+};

--- a/backend/src/services/userService.js
+++ b/backend/src/services/userService.js
@@ -19,3 +19,11 @@ export const createUser = async ({ name, email, password, phone, role = "custome
   );
   return result.insertId;
 };
+
+export const listUsers = async () => {
+  return query(
+    `SELECT id, name, email, phone, role, created_at AS createdAt
+     FROM users
+     ORDER BY created_at DESC`
+  );
+};

--- a/mobile/app/(tabs)/admin.jsx
+++ b/mobile/app/(tabs)/admin.jsx
@@ -1,16 +1,50 @@
-import { useEffect, useState } from "react";
-import { View, Text, StyleSheet, ScrollView, TouchableOpacity, ActivityIndicator, Alert } from "react-native";
+import { useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  ActivityIndicator,
+  Alert,
+  TextInput,
+} from "react-native";
 import { useAuth } from "@/contexts/AuthContext";
-import { orderApi, catalogApi } from "@/services/api";
+import { orderApi, catalogApi, adminApi } from "@/services/api";
 import { COLORS } from "@/constants/colors";
+
+const PRODUCT_FORM_INITIAL = {
+  name: "",
+  description: "",
+  price: "",
+  imageUrl: "",
+  stock: "0",
+  categoryId: null,
+  active: true,
+};
+
+const TABS = [
+  { key: "dashboard", label: "Resumen" },
+  { key: "products", label: "Productos" },
+  { key: "users", label: "Usuarios" },
+];
 
 export default function AdminScreen() {
   const { user, token } = useAuth();
   const [orders, setOrders] = useState([]);
   const [products, setProducts] = useState([]);
+  const [categories, setCategories] = useState([]);
+  const [usersList, setUsersList] = useState([]);
+  const [dashboard, setDashboard] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [updating, setUpdating] = useState(false);
+  const [activeTab, setActiveTab] = useState("dashboard");
+  const [productFormVisible, setProductFormVisible] = useState(false);
+  const [productForm, setProductForm] = useState(PRODUCT_FORM_INITIAL);
+  const [editingProduct, setEditingProduct] = useState(null);
+  const [savingProduct, setSavingProduct] = useState(false);
+  const [deletingProductId, setDeletingProductId] = useState(null);
 
   const isAdmin = user?.role === "admin";
 
@@ -20,12 +54,25 @@ export default function AdminScreen() {
       setLoading(true);
       setError(null);
       try {
-        const [ordersResponse, productsResponse] = await Promise.all([
-          orderApi.allOrders(token),
-          catalogApi.products(),
-        ]);
+        const [ordersResponse, productsResponse, categoriesResponse, dashboardResponse, usersResponse] =
+          await Promise.all([
+            orderApi.allOrders(token),
+            catalogApi.products(),
+            catalogApi.categories(),
+            adminApi.dashboard(token),
+            adminApi.users(token),
+          ]);
         setOrders(ordersResponse.orders || []);
         setProducts(productsResponse.products || []);
+        setCategories(categoriesResponse.categories || []);
+        setDashboard(dashboardResponse);
+        setUsersList(usersResponse.users || []);
+        setProductForm((prev) => ({
+          ...prev,
+          categoryId: categoriesResponse.categories?.[0]
+            ? String(categoriesResponse.categories[0].id)
+            : prev.categoryId,
+        }));
       } catch (err) {
         setError(err.message || "No pudimos obtener la información administrativa");
       } finally {
@@ -41,6 +88,16 @@ export default function AdminScreen() {
     setProducts(response.products || []);
   };
 
+  const refreshDashboard = async () => {
+    const response = await adminApi.dashboard(token);
+    setDashboard(response);
+  };
+
+  const refreshUsers = async () => {
+    const response = await adminApi.users(token);
+    setUsersList(response.users || []);
+  };
+
   const handleStatusChange = async (orderId, status) => {
     try {
       setUpdating(true);
@@ -48,6 +105,7 @@ export default function AdminScreen() {
       setOrders((prev) =>
         prev.map((order) => (order.id === orderId ? { ...order, status: updated.status } : order))
       );
+      await refreshDashboard();
       return updated;
     } catch (err) {
       Alert.alert("Error actualizando el estado", err.message || "Intenta nuevamente");
@@ -68,13 +126,124 @@ export default function AdminScreen() {
         categoryId: product.category_id,
         active: product.active ? 0 : 1,
       });
-      await refreshProducts();
+      await Promise.all([refreshProducts(), refreshDashboard()]);
     } catch (err) {
       Alert.alert("Error actualizando el producto", err.message || "Intenta de nuevo");
     } finally {
       setUpdating(false);
     }
   };
+
+  const openCreateProduct = () => {
+    setEditingProduct(null);
+    setProductForm({
+      ...PRODUCT_FORM_INITIAL,
+      categoryId: categories[0] ? String(categories[0].id) : null,
+    });
+    setProductFormVisible(true);
+  };
+
+  const openEditProduct = (product) => {
+    setEditingProduct(product);
+    setProductForm({
+      name: product.name || "",
+      description: product.description || "",
+      price: product.price != null ? String(product.price) : "",
+      imageUrl: product.image_url || "",
+      stock: product.stock != null ? String(product.stock) : "0",
+      categoryId: product.category_id != null ? String(product.category_id) : null,
+      active: !!product.active,
+    });
+    setProductFormVisible(true);
+  };
+
+  const closeProductForm = () => {
+    setProductFormVisible(false);
+    setEditingProduct(null);
+    setProductForm({
+      ...PRODUCT_FORM_INITIAL,
+      categoryId: categories[0] ? String(categories[0].id) : null,
+    });
+  };
+
+  const handleProductFormChange = (field, value) => {
+    setProductForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmitProduct = async () => {
+    if (!productForm.name.trim()) {
+      Alert.alert("Falta información", "El nombre del producto es obligatorio");
+      return;
+    }
+
+    if (!productForm.price || Number.isNaN(Number(productForm.price))) {
+      Alert.alert("Precio inválido", "Ingresa un precio válido");
+      return;
+    }
+
+    if (!productForm.categoryId) {
+      Alert.alert("Selecciona categoría", "Elige una categoría para el producto");
+      return;
+    }
+
+    const payload = {
+      name: productForm.name.trim(),
+      description: productForm.description.trim(),
+      price: Number(productForm.price),
+      imageUrl: productForm.imageUrl.trim(),
+      stock: Number(productForm.stock || 0),
+      categoryId: Number(productForm.categoryId),
+      active: productForm.active ? 1 : 0,
+    };
+
+    try {
+      setSavingProduct(true);
+      if (editingProduct) {
+        await catalogApi.updateProduct(token, editingProduct.id, payload);
+      } else {
+        await catalogApi.createProduct(token, payload);
+      }
+      await Promise.all([refreshProducts(), refreshDashboard()]);
+      closeProductForm();
+    } catch (err) {
+      Alert.alert("Error guardando producto", err.message || "Intenta nuevamente");
+    } finally {
+      setSavingProduct(false);
+    }
+  };
+
+  const handleDeleteProduct = (product) => {
+    Alert.alert("Eliminar producto", `¿Seguro que deseas eliminar ${product.name}?`, [
+      { text: "Cancelar", style: "cancel" },
+      {
+        text: "Eliminar",
+        style: "destructive",
+        onPress: async () => {
+          try {
+            setDeletingProductId(product.id);
+            await catalogApi.deleteProduct(token, product.id);
+            await Promise.all([refreshProducts(), refreshDashboard()]);
+          } catch (err) {
+            Alert.alert("Error eliminando", err.message || "No se pudo eliminar");
+          } finally {
+            setDeletingProductId(null);
+          }
+        },
+      },
+    ]);
+  };
+
+  const formattedSummary = useMemo(() => {
+    if (!dashboard) return [];
+    return [
+      { label: "Ventas totales", value: `$${dashboard.summary.totalRevenue.toFixed(2)}` },
+      { label: "Pedidos", value: String(dashboard.summary.totalOrders) },
+      { label: "Pagados", value: String(dashboard.summary.paidOrders) },
+      { label: "Pendientes", value: String(dashboard.summary.pendingOrders) },
+      { label: "Cancelados", value: String(dashboard.summary.cancelledOrders) },
+      { label: "Productos activos", value: String(dashboard.inventory.activeProducts) },
+    ];
+  }, [dashboard]);
 
   if (!isAdmin) {
     return (
@@ -96,74 +265,318 @@ export default function AdminScreen() {
   return (
     <ScrollView contentContainerStyle={styles.container}>
       <Text style={styles.title}>Panel de administración</Text>
-      <Text style={styles.subtitle}>Gestiona pedidos y disponibilidad del menú en un solo lugar.</Text>
+      <Text style={styles.subtitle}>Gestiona pedidos, inventario, usuarios y métricas clave.</Text>
+
+      <View style={styles.tabBar}>
+        {TABS.map((tab) => (
+          <TouchableOpacity
+            key={tab.key}
+            style={[styles.tabButton, activeTab === tab.key && styles.tabButtonActive]}
+            onPress={() => setActiveTab(tab.key)}
+          >
+            <Text style={[styles.tabButtonText, activeTab === tab.key && styles.tabButtonTextActive]}>
+              {tab.label}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
 
       {error && <Text style={styles.error}>{error}</Text>}
 
-      <View style={styles.section}>
-        <View style={styles.sectionHeader}>
-          <Text style={styles.sectionTitle}>Pedidos recientes</Text>
-          {updating && <ActivityIndicator color={COLORS.primary} />}
-        </View>
-        {orders.length === 0 ? (
-          <Text style={styles.emptyText}>Aún no hay pedidos registrados.</Text>
-        ) : (
-          orders.map((order) => (
-            <View key={order.id} style={styles.card}>
-              <View style={styles.cardHeader}>
-                <Text style={styles.cardTitle}>Orden #{order.id}</Text>
-                <Text style={[styles.badge, styles[`status${order.status}`] || styles.badge]}>{order.status}</Text>
-              </View>
-              <Text style={styles.cardSubtitle}>
-                Cliente: {order.customerName || "Invitado"} - Total ${Number(order.total).toFixed(2)}
-              </Text>
-              <View style={styles.orderItems}>
-                {order.items?.map((item) => (
-                  <Text key={item.id} style={styles.orderItem}>
-                    {item.quantity}x {item.name}
-                  </Text>
+      {activeTab === "dashboard" && (
+        <View style={styles.section}>
+          {dashboard ? (
+            <>
+              <View style={styles.metricsGrid}>
+                {formattedSummary.map((item) => (
+                  <View key={item.label} style={styles.metricCard}>
+                    <Text style={styles.metricLabel}>{item.label}</Text>
+                    <Text style={styles.metricValue}>{item.value}</Text>
+                  </View>
                 ))}
               </View>
-              <View style={styles.actionsRow}>
-                <TouchableOpacity style={styles.actionButton} onPress={() => handleStatusChange(order.id, "paid")}>
-                  <Text style={styles.actionButtonText}>Marcar pagado</Text>
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.actionButton, styles.dangerButton]}
-                  onPress={() => handleStatusChange(order.id, "cancelled")}
-                >
-                  <Text style={[styles.actionButtonText, styles.dangerButtonText]}>Cancelar</Text>
-                </TouchableOpacity>
-              </View>
-            </View>
-          ))
-        )}
-      </View>
 
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Inventario activo</Text>
-        {products.length === 0 ? (
-          <Text style={styles.emptyText}>No hay productos registrados todavía.</Text>
-        ) : (
-          products.map((product) => (
-            <View key={product.id} style={styles.card}>
-              <View style={styles.cardHeader}>
-                <Text style={styles.cardTitle}>{product.name}</Text>
-                <Text style={styles.cardSubtitle}>{product.category_name}</Text>
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>Ventas recientes</Text>
+                {dashboard.salesByMonth.length === 0 ? (
+                  <Text style={styles.emptyText}>Sin datos todavía.</Text>
+                ) : (
+                  dashboard.salesByMonth.map((row) => (
+                    <View key={row.month} style={styles.inlineCard}>
+                      <Text style={styles.inlineCardTitle}>{row.month}</Text>
+                      <Text style={styles.inlineCardSubtitle}>
+                        {row.orders} pedidos • ${row.revenue.toFixed(2)}
+                      </Text>
+                    </View>
+                  ))
+                )}
               </View>
-              <Text style={styles.cardSubtitle}>Stock: {product.stock} unidades</Text>
-              <Text style={styles.cardSubtitle}>${Number(product.price).toFixed(2)}</Text>
-              <View style={styles.actionsRow}>
-                <TouchableOpacity style={styles.actionButton} onPress={() => handleToggleProduct(product)}>
-                  <Text style={styles.actionButtonText}>
-                    {product.active ? "Despublicar" : "Publicar"}
+
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>Top productos</Text>
+                {dashboard.topProducts.length === 0 ? (
+                  <Text style={styles.emptyText}>Todavía no hay productos vendidos.</Text>
+                ) : (
+                  dashboard.topProducts.map((product) => (
+                    <View key={product.id} style={styles.inlineCard}>
+                      <Text style={styles.inlineCardTitle}>{product.name}</Text>
+                      <Text style={styles.inlineCardSubtitle}>
+                        {product.unitsSold} vendidos • ${product.revenue.toFixed(2)}
+                      </Text>
+                    </View>
+                  ))
+                )}
+              </View>
+            </>
+          ) : (
+            <ActivityIndicator color={COLORS.primary} />
+          )}
+
+          <View style={styles.section}>
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>Pedidos recientes</Text>
+              {updating && <ActivityIndicator color={COLORS.primary} />}
+            </View>
+            {orders.length === 0 ? (
+              <Text style={styles.emptyText}>Aún no hay pedidos registrados.</Text>
+            ) : (
+              orders.map((order) => (
+                <View key={order.id} style={styles.card}>
+                  <View style={styles.cardHeader}>
+                    <Text style={styles.cardTitle}>Orden #{order.id}</Text>
+                    <Text style={[styles.badge, styles[`status${order.status}`] || styles.badge]}>
+                      {order.status}
+                    </Text>
+                  </View>
+                  <Text style={styles.cardSubtitle}>
+                    Cliente: {order.customerName || "Invitado"} - Total ${Number(order.total).toFixed(2)}
+                  </Text>
+                  <View style={styles.orderItems}>
+                    {order.items?.map((item) => (
+                      <Text key={item.id} style={styles.orderItem}>
+                        {item.quantity}x {item.name}
+                      </Text>
+                    ))}
+                  </View>
+                  <View style={styles.actionsRow}>
+                    <TouchableOpacity
+                      style={styles.actionButton}
+                      onPress={() => handleStatusChange(order.id, "paid")}
+                    >
+                      <Text style={styles.actionButtonText}>Marcar pagado</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={[styles.actionButton, styles.dangerButton]}
+                      onPress={() => handleStatusChange(order.id, "cancelled")}
+                    >
+                      <Text style={[styles.actionButtonText, styles.dangerButtonText]}>Cancelar</Text>
+                    </TouchableOpacity>
+                  </View>
+                </View>
+              ))
+            )}
+          </View>
+        </View>
+      )}
+
+      {activeTab === "products" && (
+        <View style={styles.section}>
+          <View style={styles.sectionHeader}>
+            <Text style={styles.sectionTitle}>Inventario</Text>
+            <TouchableOpacity style={styles.primaryButton} onPress={openCreateProduct}>
+              <Text style={styles.primaryButtonText}>Nuevo producto</Text>
+            </TouchableOpacity>
+          </View>
+
+          {productFormVisible && (
+            <View style={styles.card}>
+              <Text style={styles.cardTitle}>
+                {editingProduct ? "Editar producto" : "Crear producto"}
+              </Text>
+
+              <View style={styles.formRow}>
+                <Text style={styles.inputLabel}>Nombre</Text>
+                <TextInput
+                  value={productForm.name}
+                  onChangeText={(text) => handleProductFormChange("name", text)}
+                  style={styles.input}
+                  placeholder="Helado artesanal"
+                  placeholderTextColor={COLORS.textLight}
+                />
+              </View>
+
+              <View style={styles.formRow}>
+                <Text style={styles.inputLabel}>Descripción</Text>
+                <TextInput
+                  value={productForm.description}
+                  onChangeText={(text) => handleProductFormChange("description", text)}
+                  style={[styles.input, styles.multilineInput]}
+                  placeholder="Describe los ingredientes"
+                  placeholderTextColor={COLORS.textLight}
+                  multiline
+                />
+              </View>
+
+              <View style={styles.formRowInline}>
+                <View style={styles.formColumn}>
+                  <Text style={styles.inputLabel}>Precio</Text>
+                  <TextInput
+                    value={productForm.price}
+                    onChangeText={(text) => handleProductFormChange("price", text)}
+                    style={styles.input}
+                    keyboardType="decimal-pad"
+                    placeholder="0.00"
+                    placeholderTextColor={COLORS.textLight}
+                  />
+                </View>
+                <View style={styles.formColumn}>
+                  <Text style={styles.inputLabel}>Stock</Text>
+                  <TextInput
+                    value={productForm.stock}
+                    onChangeText={(text) => handleProductFormChange("stock", text)}
+                    style={styles.input}
+                    keyboardType="number-pad"
+                    placeholder="0"
+                    placeholderTextColor={COLORS.textLight}
+                  />
+                </View>
+              </View>
+
+              <View style={styles.formRow}>
+                <Text style={styles.inputLabel}>Imagen (URL)</Text>
+                <TextInput
+                  value={productForm.imageUrl}
+                  onChangeText={(text) => handleProductFormChange("imageUrl", text)}
+                  style={styles.input}
+                  placeholder="https://..."
+                  placeholderTextColor={COLORS.textLight}
+                  autoCapitalize="none"
+                />
+              </View>
+
+              <View style={styles.formRow}>
+                <Text style={styles.inputLabel}>Categoría</Text>
+                <View style={styles.chipsContainer}>
+                  {categories.length === 0 ? (
+                    <Text style={styles.emptyText}>No hay categorías disponibles.</Text>
+                  ) : (
+                    categories.map((category) => {
+                      const active = productForm.categoryId === String(category.id);
+                      return (
+                        <TouchableOpacity
+                          key={category.id}
+                          style={[styles.chip, active && styles.chipActive]}
+                          onPress={() => handleProductFormChange("categoryId", String(category.id))}
+                        >
+                          <Text style={[styles.chipText, active && styles.chipTextActive]}>{category.name}</Text>
+                        </TouchableOpacity>
+                      );
+                    })
+                  )}
+                </View>
+              </View>
+
+              <View style={styles.formRow}>
+                <Text style={styles.inputLabel}>Estado</Text>
+                <TouchableOpacity
+                  style={[styles.toggleButton, productForm.active && styles.toggleButtonActive]}
+                  onPress={() => handleProductFormChange("active", !productForm.active)}
+                >
+                  <Text style={[styles.toggleButtonText, productForm.active && styles.toggleButtonTextActive]}>
+                    {productForm.active ? "Publicado" : "Oculto"}
                   </Text>
                 </TouchableOpacity>
               </View>
+
+              <View style={styles.formActions}>
+                <TouchableOpacity
+                  style={[styles.primaryButton, styles.formButton]}
+                  onPress={handleSubmitProduct}
+                  disabled={savingProduct}
+                >
+                  {savingProduct ? (
+                    <ActivityIndicator color={COLORS.white} />
+                  ) : (
+                    <Text style={styles.primaryButtonText}>
+                      {editingProduct ? "Guardar cambios" : "Crear producto"}
+                    </Text>
+                  )}
+                </TouchableOpacity>
+                <TouchableOpacity style={[styles.secondaryButton, styles.formButton]} onPress={closeProductForm}>
+                  <Text style={styles.secondaryButtonText}>Cancelar</Text>
+                </TouchableOpacity>
+              </View>
             </View>
-          ))
-        )}
-      </View>
+          )}
+
+          {products.length === 0 ? (
+            <Text style={styles.emptyText}>No hay productos registrados todavía.</Text>
+          ) : (
+            products.map((product) => (
+              <View key={product.id} style={styles.card}>
+                <View style={styles.cardHeader}>
+                  <View>
+                    <Text style={styles.cardTitle}>{product.name}</Text>
+                    <Text style={styles.cardSubtitle}>{product.category_name}</Text>
+                  </View>
+                  <Text style={[styles.badge, product.active ? styles.statuspaid : styles.statuscancelled]}>
+                    {product.active ? "Activo" : "Inactivo"}
+                  </Text>
+                </View>
+                <Text style={styles.cardSubtitle}>Stock: {product.stock} unidades</Text>
+                <Text style={styles.cardSubtitle}>${Number(product.price).toFixed(2)}</Text>
+                <View style={styles.actionsRow}>
+                  <TouchableOpacity style={styles.actionButton} onPress={() => openEditProduct(product)}>
+                    <Text style={styles.actionButtonText}>Editar</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity style={styles.actionButton} onPress={() => handleToggleProduct(product)}>
+                    <Text style={styles.actionButtonText}>
+                      {product.active ? "Despublicar" : "Publicar"}
+                    </Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.actionButton, styles.dangerButton]}
+                    onPress={() => handleDeleteProduct(product)}
+                    disabled={deletingProductId === product.id}
+                  >
+                    {deletingProductId === product.id ? (
+                      <ActivityIndicator color={COLORS.error} />
+                    ) : (
+                      <Text style={[styles.actionButtonText, styles.dangerButtonText]}>Eliminar</Text>
+                    )}
+                  </TouchableOpacity>
+                </View>
+              </View>
+            ))
+          )}
+        </View>
+      )}
+
+      {activeTab === "users" && (
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Usuarios registrados</Text>
+          {usersList.length === 0 ? (
+            <Text style={styles.emptyText}>Todavía no hay usuarios registrados.</Text>
+          ) : (
+            usersList.map((item) => (
+              <View key={item.id} style={styles.card}>
+                <View style={styles.cardHeader}>
+                  <Text style={styles.cardTitle}>{item.name}</Text>
+                  <Text style={[styles.badge, item.role === "admin" ? styles.statuspaid : styles.statuspending]}>
+                    {item.role}
+                  </Text>
+                </View>
+                <Text style={styles.cardSubtitle}>{item.email}</Text>
+                {item.phone && <Text style={styles.cardSubtitle}>Teléfono: {item.phone}</Text>}
+                <Text style={styles.cardSubtitle}>Registrado: {new Date(item.createdAt).toLocaleDateString()}</Text>
+              </View>
+            ))
+          )}
+          <TouchableOpacity style={styles.refreshButton} onPress={refreshUsers}>
+            <Text style={styles.refreshButtonText}>Actualizar usuarios</Text>
+          </TouchableOpacity>
+        </View>
+      )}
     </ScrollView>
   );
 }
@@ -192,8 +605,39 @@ const styles = StyleSheet.create({
     marginTop: 6,
     fontSize: 14,
   },
+  tabBar: {
+    flexDirection: "row",
+    backgroundColor: COLORS.white,
+    borderRadius: 16,
+    padding: 6,
+    marginTop: 20,
+    gap: 6,
+    shadowColor: COLORS.shadow,
+    shadowOpacity: 0.05,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 3,
+  },
+  tabButton: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 12,
+    alignItems: "center",
+    backgroundColor: "transparent",
+  },
+  tabButtonActive: {
+    backgroundColor: COLORS.primary,
+  },
+  tabButtonText: {
+    color: COLORS.textLight,
+    fontWeight: "600",
+  },
+  tabButtonTextActive: {
+    color: COLORS.white,
+  },
   section: {
     gap: 12,
+    marginTop: 24,
   },
   sectionHeader: {
     flexDirection: "row",
@@ -204,6 +648,32 @@ const styles = StyleSheet.create({
     fontSize: 20,
     fontWeight: "700",
     color: COLORS.text,
+  },
+  metricsGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 12,
+  },
+  metricCard: {
+    flexBasis: "48%",
+    backgroundColor: COLORS.card,
+    borderRadius: 16,
+    padding: 16,
+    shadowColor: COLORS.shadow,
+    shadowOpacity: 0.06,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 3,
+  },
+  metricLabel: {
+    color: COLORS.textLight,
+    fontSize: 13,
+    marginBottom: 4,
+  },
+  metricValue: {
+    color: COLORS.text,
+    fontSize: 20,
+    fontWeight: "700",
   },
   card: {
     backgroundColor: COLORS.card,
@@ -230,6 +700,24 @@ const styles = StyleSheet.create({
     color: COLORS.textLight,
     fontSize: 14,
   },
+  inlineCard: {
+    backgroundColor: COLORS.card,
+    borderRadius: 16,
+    padding: 12,
+    shadowColor: COLORS.shadow,
+    shadowOpacity: 0.05,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
+  },
+  inlineCardTitle: {
+    fontWeight: "700",
+    color: COLORS.text,
+  },
+  inlineCardSubtitle: {
+    color: COLORS.textLight,
+    marginTop: 4,
+  },
   orderItems: {
     gap: 4,
   },
@@ -251,6 +739,32 @@ const styles = StyleSheet.create({
   actionButtonText: {
     color: COLORS.white,
     fontWeight: "700",
+  },
+  primaryButton: {
+    backgroundColor: COLORS.primary,
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  primaryButtonText: {
+    color: COLORS.white,
+    fontWeight: "700",
+  },
+  secondaryButton: {
+    backgroundColor: COLORS.card,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: 14,
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  secondaryButtonText: {
+    color: COLORS.text,
+    fontWeight: "600",
   },
   dangerButton: {
     backgroundColor: COLORS.errorLight,
@@ -281,5 +795,98 @@ const styles = StyleSheet.create({
   },
   error: {
     color: COLORS.error,
+  },
+  formRow: {
+    marginTop: 12,
+    gap: 6,
+  },
+  formRowInline: {
+    flexDirection: "row",
+    gap: 12,
+    marginTop: 12,
+  },
+  formColumn: {
+    flex: 1,
+    gap: 6,
+  },
+  inputLabel: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: COLORS.text,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    backgroundColor: COLORS.white,
+    color: COLORS.text,
+  },
+  multilineInput: {
+    minHeight: 80,
+    textAlignVertical: "top",
+  },
+  chipsContainer: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    backgroundColor: COLORS.white,
+  },
+  chipActive: {
+    backgroundColor: COLORS.accent,
+    borderColor: COLORS.accent,
+  },
+  chipText: {
+    color: COLORS.textLight,
+    fontWeight: "600",
+  },
+  chipTextActive: {
+    color: COLORS.white,
+  },
+  toggleButton: {
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: 14,
+    paddingVertical: 10,
+    alignItems: "center",
+  },
+  toggleButtonActive: {
+    backgroundColor: COLORS.success,
+    borderColor: COLORS.success,
+  },
+  toggleButtonText: {
+    color: COLORS.textLight,
+    fontWeight: "600",
+  },
+  toggleButtonTextActive: {
+    color: COLORS.white,
+  },
+  formActions: {
+    flexDirection: "row",
+    gap: 12,
+    marginTop: 18,
+  },
+  formButton: {
+    flex: 1,
+  },
+  refreshButton: {
+    marginTop: 12,
+    alignSelf: "flex-start",
+    backgroundColor: COLORS.accent,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 14,
+  },
+  refreshButtonText: {
+    color: COLORS.white,
+    fontWeight: "700",
   },
 });

--- a/mobile/services/api.js
+++ b/mobile/services/api.js
@@ -67,6 +67,7 @@ export const catalogApi = {
   product: (id) => request(`/products/${id}`),
   createProduct: (token, payload) => request("/products", { method: "POST", token, body: payload }),
   updateProduct: (token, id, payload) => request(`/products/${id}`, { method: "PUT", token, body: payload }),
+  deleteProduct: (token, id) => request(`/products/${id}`, { method: "DELETE", token }),
   createCategory: (token, payload) => request("/categories", { method: "POST", token, body: payload }),
   updateCategory: (token, id, payload) => request(`/categories/${id}`, { method: "PUT", token, body: payload }),
 };
@@ -85,4 +86,9 @@ export const orderApi = {
   allOrders: (token) => request("/orders", { token }),
   updateStatus: (token, orderId, status) =>
     request(`/orders/${orderId}/status`, { method: "PATCH", token, body: { status } }),
+};
+
+export const adminApi = {
+  dashboard: (token) => request("/admin/dashboard", { token }),
+  users: (token) => request("/admin/users", { token }),
 };


### PR DESCRIPTION
## Summary
- expose administrative dashboard metrics and user listing endpoints in the backend
- extend the mobile API client with admin helpers and product deletion support
- redesign the admin tab with dashboard insights, product CRUD flows, and user management views

## Testing
- npm run lint *(fails: expo command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ec3b774a78832ea442fc5b356f5e49