### PR TITLE
Add logout control and align branding with Helados Victoria

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<h1 align="center">🍨 Helados Aurora — App móvil y API Express</h1>
+<h1 align="center">🍨 Helados Victoria — App móvil y API Express</h1>
 
 ![Demo App](/mobile/assets/images/screenshot-for-readme.png)
 
-Helados Aurora es una plataforma completa para administrar una heladería moderna:
+Helados Victoria es una plataforma completa para administrar una heladería moderna:
 
 - 👩‍🍳 Catálogo editable de helados, paletas y malteadas.
 - 🛒 Carrito persistente por usuario y flujo de checkout.
@@ -23,13 +23,8 @@ Crea un archivo `.env` con los siguientes valores:
 PORT=5001
 DB_HOST=localhost
 DB_PORT=3306
-<<<<<<< HEAD
 DB_USER=tu_usuario
 DB_PASSWORD=tu_password
-=======
-DB_USER=heladeria_bd
-DB_PASSWORD=1234
->>>>>>> a822bae (Primer commit desde VS Code - ajustes y conexión API)
 DB_NAME=heladeria_db
 JWT_SECRET=tu_secreto_super_seguro
 NODE_ENV=development
@@ -107,4 +102,4 @@ Abre el enlace en Expo Go o en un emulador para probar la experiencia móvil.
 - Gestión avanzada de inventario (promociones, cupones).
 - Notificaciones push cuando un pedido cambie de estado.
 
-¡Disfruta creando experiencias dulces con Helados Aurora! 🍧
+¡Disfruta creando experiencias dulces con Helados Victoria! 🍧

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -5,11 +5,7 @@ export const ENV = {
   DB_HOST: process.env.DB_HOST || "localhost",
   DB_PORT: process.env.DB_PORT ? Number(process.env.DB_PORT) : 3306,
   DB_USER: process.env.DB_USER || "root",
-<<<<<<< HEAD
   DB_PASSWORD: process.env.DB_PASSWORD || "",
-=======
-  DB_PASSWORD: process.env.DB_PASSWORD || "1234",
->>>>>>> a822bae (Primer commit desde VS Code - ajustes y conexión API)
   DB_NAME: process.env.DB_NAME || "heladeria_db",
   JWT_SECRET: process.env.JWT_SECRET || "super-secret-heladeria",
   NODE_ENV: process.env.NODE_ENV,

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import { ENV } from "./config/env.js";
+import { pool } from "./config/db.js";
 import authRoutes from "./routes/authRoutes.js";
 import productRoutes from "./routes/productRoutes.js";
 import cartRoutes from "./routes/cartRoutes.js";
@@ -27,6 +28,18 @@ app.use((err, _req, res, _next) => {
   res.status(500).json({ message: "Error interno del servidor" });
 });
 
-app.listen(ENV.PORT, () => {
-  console.log(`Heladería API ejecutándose en el puerto ${ENV.PORT}`);
-});
+const startServer = async () => {
+  try {
+    await pool.query("SELECT 1");
+    console.log("✅ Conexión a MySQL establecida correctamente");
+  } catch (error) {
+    console.error("❌ No se pudo conectar a la base de datos", error.message);
+    process.exit(1);
+  }
+
+  app.listen(ENV.PORT, () => {
+    console.log(`Helados Victoria API ejecutándose en el puerto ${ENV.PORT}`);
+  });
+};
+
+startServer();

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -1,6 +1,6 @@
-# Helados Aurora Mobile
+# Helados Victoria Mobile
 
-Aplicación móvil construida con React Native + Expo para la heladería Helados Aurora. Permite a los clientes explorar el catálogo, administrar su carrito y revisar pedidos, mientras que los administradores supervisan órdenes e inventario.
+Aplicación móvil construida con React Native + Expo para la heladería Helados Victoria. Permite a los clientes explorar el catálogo, administrar su carrito y revisar pedidos, mientras que los administradores supervisan órdenes e inventario.
 
 ## Características principales
 

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "Helados Aurora",
+    "name": "Helados Victoria",
     "slug": "helados-aurora",
     "version": "1.0.0",
     "orientation": "portrait",

--- a/mobile/app/(auth)/login.jsx
+++ b/mobile/app/(auth)/login.jsx
@@ -29,7 +29,7 @@ export default function LoginScreen() {
   return (
     <View style={styles.container}>
       <View style={styles.card}>
-        <Text style={styles.title}>Bienvenido a Helados Aurora</Text>
+        <Text style={styles.title}>Bienvenido a Helados Victoria</Text>
         <Text style={styles.subtitle}>Inicia sesión para ordenar tus sabores favoritos</Text>
 
         <Text style={styles.label}>Correo electrónico</Text>

--- a/mobile/app/(auth)/register.jsx
+++ b/mobile/app/(auth)/register.jsx
@@ -34,7 +34,7 @@ export default function RegisterScreen() {
   return (
     <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
       <View style={styles.card}>
-        <Text style={styles.title}>Crea tu cuenta helada</Text>
+        <Text style={styles.title}>Únete a Helados Victoria</Text>
         <Text style={styles.subtitle}>Regístrate para gestionar tu carrito y recibir promociones</Text>
 
         <Text style={styles.label}>Nombre completo</Text>

--- a/mobile/app/(tabs)/_layout.jsx
+++ b/mobile/app/(tabs)/_layout.jsx
@@ -1,19 +1,46 @@
-import { Redirect, Tabs } from "expo-router";
+import { Redirect, Tabs, useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { TouchableOpacity, Text, StyleSheet } from "react-native";
 import { useAuth } from "@/contexts/AuthContext";
 import { COLORS } from "@/constants/colors";
 
 const TabsLayout = () => {
-  const { user, loading } = useAuth();
+  const router = useRouter();
+  const { user, loading, logout } = useAuth();
 
   if (loading) return null;
 
   if (!user) return <Redirect href="/(auth)/login" />;
 
+  const handleLogout = async () => {
+    try {
+      await logout();
+      router.replace("/(auth)/login");
+    } catch (error) {
+      console.warn("No se pudo cerrar sesión", error?.message);
+    }
+  };
+
   return (
     <Tabs
       screenOptions={{
-        headerShown: false,
+        headerShown: true,
+        headerTitle: "Helados Victoria",
+        headerTitleAlign: "center",
+        headerStyle: {
+          backgroundColor: COLORS.primary,
+        },
+        headerTintColor: COLORS.white,
+        headerTitleStyle: {
+          fontWeight: "800",
+          fontSize: 18,
+        },
+        headerRight: () => (
+          <TouchableOpacity onPress={handleLogout} style={styles.logoutButton}>
+            <Ionicons name="log-out-outline" size={20} color={COLORS.white} />
+            <Text style={styles.logoutText}>Cerrar sesión</Text>
+          </TouchableOpacity>
+        ),
         tabBarActiveTintColor: COLORS.primary,
         tabBarInactiveTintColor: COLORS.textLight,
         tabBarStyle: {
@@ -63,3 +90,18 @@ const TabsLayout = () => {
   );
 };
 export default TabsLayout;
+
+const styles = StyleSheet.create({
+  logoutButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  logoutText: {
+    color: COLORS.white,
+    fontWeight: "600",
+    fontSize: 14,
+    marginLeft: 6,
+  },
+});

--- a/mobile/app/(tabs)/index.jsx
+++ b/mobile/app/(tabs)/index.jsx
@@ -73,7 +73,7 @@ export default function HomeScreen() {
     <ScrollView contentContainerStyle={styles.container}>
       <View style={styles.hero}>
         <View style={styles.heroText}>
-          <Text style={styles.heroTag}>Heladería artesanal</Text>
+          <Text style={styles.heroTag}>Helados Victoria</Text>
           <Text style={styles.heroTitle}>Sabores hechos con amor mexicano</Text>
           <Text style={styles.heroSubtitle}>
             Descubre nuestras combinaciones de temporada, paletas artesanales y malteadas cremosas.


### PR DESCRIPTION
## Summary
- resolve lingering merge conflicts in configuration and verify the database connection before starting the API
- add a persistent logout control in the authenticated tab layout and update in-app copy to Helados Victoria
- refresh documentation and Expo config to reflect the Helados Victoria branding

## Testing
- not run (backend requires database credentials to start)


------
https://chatgpt.com/codex/tasks/task_e_68ec41e9e174832eb5fd5e3ce8952120