### PR TITLE
Handle plaintext passwords for existing users

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ DB_PASSWORD=tu_password
 DB_NAME=heladeria_db
 JWT_SECRET=tu_secreto_super_seguro
 NODE_ENV=development
+ADMIN_EMAIL=admin@helados.com
+ADMIN_PASSWORD=una_contraseña_segura
+# Opcionalmente personaliza el nombre y teléfono del administrador
+# ADMIN_NAME=Helados Admin
+# ADMIN_PHONE=5551234567
 ```
+
+Al iniciar el servidor, si `ADMIN_EMAIL` y `ADMIN_PASSWORD` están definidos se creará (o actualizará) automáticamente una cuenta administrativa con esas credenciales.
 
 ### Mobile (`/mobile`)
 

--- a/backend/src/config/env.js
+++ b/backend/src/config/env.js
@@ -9,4 +9,8 @@ export const ENV = {
   DB_NAME: process.env.DB_NAME || "heladeria_db",
   JWT_SECRET: process.env.JWT_SECRET || "super-secret-heladeria",
   NODE_ENV: process.env.NODE_ENV,
+  ADMIN_EMAIL: process.env.ADMIN_EMAIL,
+  ADMIN_PASSWORD: process.env.ADMIN_PASSWORD,
+  ADMIN_NAME: process.env.ADMIN_NAME,
+  ADMIN_PHONE: process.env.ADMIN_PHONE,
 };

--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -1,8 +1,12 @@
-import bcrypt from "bcryptjs";
 import jwt from "jsonwebtoken";
 import { validationResult } from "express-validator";
 import { ENV } from "../config/env.js";
-import { createUser, findUserByEmail, findUserById } from "../services/userService.js";
+import {
+  createUser,
+  findUserByEmail,
+  findUserById,
+  verifyUserPassword,
+} from "../services/userService.js";
 
 const generateToken = (user) =>
   jwt.sign({ id: user.id, email: user.email, role: user.role, name: user.name }, ENV.JWT_SECRET, {
@@ -48,12 +52,12 @@ export const login = async (req, res) => {
       return res.status(401).json({ message: "Credenciales inválidas" });
     }
 
-    const isPasswordValid = await bcrypt.compare(password, user.password_hash);
+    const isPasswordValid = await verifyUserPassword(user, password);
     if (!isPasswordValid) {
       return res.status(401).json({ message: "Credenciales inválidas" });
     }
 
-    const token = generateToken(user);
+    const token = generateToken({ ...user, password_hash: undefined });
     const { password_hash, ...safeUser } = user;
 
     res.json({ user: safeUser, token });

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -7,6 +7,7 @@ import productRoutes from "./routes/productRoutes.js";
 import cartRoutes from "./routes/cartRoutes.js";
 import orderRoutes from "./routes/orderRoutes.js";
 import adminRoutes from "./routes/adminRoutes.js";
+import { ensureAdminUser } from "./services/userService.js";
 
 const app = express();
 
@@ -32,6 +33,19 @@ const startServer = async () => {
   try {
     await pool.query("SELECT 1");
     console.log("✅ Conexión a MySQL establecida correctamente");
+    if (ENV.ADMIN_EMAIL && ENV.ADMIN_PASSWORD) {
+      await ensureAdminUser({
+        name: ENV.ADMIN_NAME,
+        email: ENV.ADMIN_EMAIL,
+        password: ENV.ADMIN_PASSWORD,
+        phone: ENV.ADMIN_PHONE,
+      });
+      console.log(`👤 Cuenta administrativa lista (${ENV.ADMIN_EMAIL})`);
+    } else {
+      console.warn(
+        "⚠️ Variables ADMIN_EMAIL y ADMIN_PASSWORD no configuradas. No se creó un administrador por defecto."
+      );
+    }
   } catch (error) {
     console.error("❌ No se pudo conectar a la base de datos", error.message);
     process.exit(1);

--- a/backend/src/services/userService.js
+++ b/backend/src/services/userService.js
@@ -1,6 +1,21 @@
 import bcrypt from "bcryptjs";
 import { pool, query } from "../config/db.js";
 
+const BCRYPT_ROUNDS = 10;
+
+const hashPassword = (password) => bcrypt.hash(password, BCRYPT_ROUNDS);
+
+const isBcryptHash = (value) =>
+  typeof value === "string" && /^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$/.test(value);
+
+const updatePasswordHash = async (userId, password) => {
+  const passwordHash = await hashPassword(password);
+  await pool.execute("UPDATE users SET password_hash = :passwordHash WHERE id = :id", {
+    passwordHash,
+    id: userId,
+  });
+};
+
 export const findUserByEmail = async (email) => {
   const users = await query("SELECT * FROM users WHERE email = :email", { email });
   return users[0];
@@ -12,10 +27,11 @@ export const findUserById = async (id) => {
 };
 
 export const createUser = async ({ name, email, password, phone, role = "customer" }) => {
-  const passwordHash = await bcrypt.hash(password, 10);
+  const passwordHash = await hashPassword(password);
+  const normalizedPhone = phone ?? null;
   const [result] = await pool.execute(
     "INSERT INTO users (name, email, password_hash, phone, role) VALUES (:name, :email, :passwordHash, :phone, :role)",
-    { name, email, passwordHash, phone, role }
+    { name, email, passwordHash, phone: normalizedPhone, role }
   );
   return result.insertId;
 };
@@ -26,4 +42,53 @@ export const listUsers = async () => {
      FROM users
      ORDER BY created_at DESC`
   );
+};
+
+export const verifyUserPassword = async (user, password) => {
+  if (!user?.password_hash) {
+    return false;
+  }
+
+  if (isBcryptHash(user.password_hash)) {
+    try {
+      return await bcrypt.compare(password, user.password_hash);
+    } catch (error) {
+      return false;
+    }
+  }
+
+  if (user.password_hash === password) {
+    await updatePasswordHash(user.id, password);
+    return true;
+  }
+
+  return false;
+};
+
+export const ensureAdminUser = async ({ name, email, password, phone }) => {
+  if (!email || !password) {
+    return;
+  }
+
+  const existingAdmin = await findUserByEmail(email);
+  if (!existingAdmin) {
+    await createUser({
+      name: name || "Administrador",
+      email,
+      password,
+      phone,
+      role: "admin",
+    });
+    return;
+  }
+
+  if (existingAdmin.role !== "admin") {
+    await pool.execute("UPDATE users SET role = 'admin' WHERE id = :id", { id: existingAdmin.id });
+  }
+
+  const hasValidPassword = await verifyUserPassword(existingAdmin, password);
+
+  if (!hasValidPassword) {
+    await updatePasswordHash(existingAdmin.id, password);
+  }
 };


### PR DESCRIPTION
## Summary
- add shared password hashing utilities to the user service
- automatically detect and rehash plaintext passwords during login or admin provisioning
- switch login flow to reuse the service helper when validating credentials

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ec48d7ef98832e9dd637541e0fafe8